### PR TITLE
Multicast Stack Fix

### DIFF
--- a/sys/netinet/ip_mroute.c
+++ b/sys/netinet/ip_mroute.c
@@ -735,7 +735,7 @@ X_ip_mrouter_done(void)
 	    if_allmulti(ifp, 0);
 	}
     }
-    bzero((caddr_t)V_viftable, sizeof(V_viftable));
+    bzero((caddr_t)V_viftable, sizeof(*V_viftable) * MAXVIFS);
     V_numvifs = 0;
     V_pim_assert_enabled = 0;
     


### PR DESCRIPTION
Currently the multicast stack in stable is seriously broken by incorrect dynamic memory allocation of multicast vif arrays. This commit fixes this issue.

Fixes: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=248512#add_comment
Fixes: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=246629

Other references:
https://forum.opnsense.org/index.php?topic=18490.0
https://redmine.pfsense.org/issues/10558#change-46850